### PR TITLE
fixed x64 platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ DOWNLOAD=$(if $(CURL_CMD),$(CURL_CMD),$(if $(WGET_CMD),$(WGET_CMD),$(error curl 
 ######################################################################
 
 NODE_OS:=$(subst Darwin,darwin,$(subst Linux,linux,$(shell uname -s)))
-NODE_ARCH:=$(subst x86_64,x86,$(subst i386,x86,$(subst i686,x86,$(shell uname -m))))
+NODE_ARCH:=$(subst x86_64,x64,$(subst i386,x86,$(subst i686,x86,$(shell uname -m))))
 NODE_VERSION:=0.12.6
 NODE_URLBASE:=http://nodejs.org/dist
 NODE_TAR:=node-v$(NODE_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.gz


### PR DESCRIPTION
Hi! Thanks for the node check. The checks works but downloads the wrong version for the x64 platform which refuses to work if no x86 compatibility layer is installed. This fixes the download. 
