### PR TITLE
Use iterative refinement guided by B-spline for conic drawing, cleanup and fix computation of k.

### DIFF
--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -699,7 +699,7 @@ eval_helper.drawconic = function(conicMatrix, modifs) {
             return csctx.lineTo(x2, y2);
         var cx = (k20 * ux + k11 * uy + k10 * uz) / cz;
         var cy = (k11 * ux + k02 * uy + k01 * uz) / cz;
-		// m is the midpoint of x1 and x2
+        // m is the midpoint of x1 and x2
         var mx = 0.5 * (x1 + x2);
         var my = 0.5 * (y1 + y2);
         var c = (c20 * cx + c11 * cy + c10) * cx + (c02 * cy + c01) * cy + c00;

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -600,7 +600,7 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
             if ((sol[0] - eps < coord && coord < sol[1] + eps) === smInside)
                 cleanPush(vert, other, coord, "corner");
         } else {
-            if (k00 >= 0) {
+            if (k00 > 0) {
                 var x, y;
                 if (vert) { // xFlat for vertical tangent to oval
                     x = xFlat[fwd ? 0 : 1];

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -481,7 +481,6 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
     Render2D.preDrawCurve();
 
     var maxError = 0.04; // squared distance in px^2
-    var sol, x, y, i;
 
     // Transform matrix of conic to match canvas coordinate system
     var mat = List.normalizeMax(conicMatrix);
@@ -551,8 +550,9 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
 
     function doBoundary(sol, other, vert, sort, extent) {
         // Edge cannot be inside if there are no solutions.
+        var t;
         if (sol !== null) {
-            var coord, pt, t;
+            var coord, pt;
             var extent0 = sort > 0 ? 0 : extent;
             var extent1 = sort > 0 ? extent : 0;
             // Only include each first corner that falls within the conic
@@ -606,11 +606,6 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
             doBoundary(xTop, 0, false, -1, csw)))
         return;
 
-    if (csctx.special) { // begin DEBUG code
-        for (i = 0; i < points.length; ++i)
-            csctx.special.push([points[i].x, points[i].y]);
-    } // end DEBUG code
-
     csctx.beginPath();
     var next;
     var n = points.length;
@@ -620,14 +615,14 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
     var previousBegin = null;
     do {
         next = points[i];
-        if (next.t == "begin") {
+        if (next.t === "begin") {
             previousBegin = next;
             break;
         }
     } while (--i > 0);
     if (!(k00 < 0 && previous.t === "end")) csctx.moveTo(previous.x, previous.y);
     for (i = 0; i < n; ++i) {
-        var next = points[i];
+        next = points[i];
         switch (next.t) {
             case "begin":
                 previousBegin = next;
@@ -643,12 +638,17 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
                 if (k00 < 0) drawArc(next, previousBegin);
                 break;
             case "split":
-            default:
                 drawArc(previous, next);
                 break;
         }
         previous = next;
     }
+	
+    if (csctx.special) { // begin DEBUG code
+        for (i = 0; i < points.length; ++i)
+            csctx.special.push([points[i].x, points[i].y]);
+    } // end DEBUG code
+
     if (df === "D") {
         csctx.stroke();
     }

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -405,7 +405,7 @@ DbgCtx.prototype = {
         this.delegate.lineTo(x, y);
     },
     quadraticCurveTo: function(x1, y1, x, y) {
-        console.log("quadratocCurveTo(" + x1 + ", " + y1 + ", " + x + ", " + y + ")");
+        console.log("quadraticCurveTo(" + x1 + ", " + y1 + ", " + x + ", " + y + ")");
         this.ctls.push([x1, y1]);
         this.pts.push([x, y]);
         this.delegate.quadraticCurveTo(x1, y1, x, y);
@@ -706,7 +706,18 @@ eval_helper.drawconic = function(conicMatrix, modifs) {
         var m = (c20 * mx + c11 * my + c10) * mx + (c02 * my + c01) * my + c00;
         var k = 1 / (1 + Math.sqrt(-c / m));
         if (isNaN(k)) k = 1;
-        refine(x1, y1, cx, cy, x2, y2, k, 0);
+        var j = 1 - k;
+        var dx = cx - mx;
+        var dy = cy - my;
+        var s = dx * dx + dy * dy;
+        if (s < maxError) {
+            csctx.lineTo(x2, y2);
+        } else if (s * j * j < maxError) {
+            csctx.lineTo(cx, cy);
+            csctx.lineTo(x2, y2);
+        } else {
+            refine(x1, y1, cx, cy, x2, y2, k, 0);
+        }
     }
 
     function refine(Ax, Ay, Bx, By, Cx, Cy, k, n) {
@@ -719,8 +730,9 @@ eval_helper.drawconic = function(conicMatrix, modifs) {
         var kBy = k * By;
         var Gx = kBx + j * Mx;
         var Gy = kBy + j * My;
-        if ((Fx - Gx) * (Fx - Gx) + (Fy - Gy) * (Fy - Gy) < maxError ||
-            n > 10) {
+        var dx = Fx - Gx;
+        var dy = Fy - Gy;
+        if (dx * dx + dy * dy < maxError || n > 10) {
             csctx.quadraticCurveTo(Bx, By, Cx, Cy);
         } else {
             var kr = 1 / (Math.sqrt(2 * j) + 1);

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -513,10 +513,6 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
     var det = c02 * k02 + c11 * k11 + c20 * k20 - c00 * k00;
     if (!isFinite(det)) return;
 
-    // conic center
-    var ccx = k10 / k00;
-    var ccy = k01 / k00;
-
     // Are midpoints of horizontal and vertical intersections inside the conic?
     var hInside = true;
     var vInside = true;
@@ -527,7 +523,8 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
 
     // conic(x, y) === 0 is the equation for the conic. It distinguishes one
     // side of the conic from the other for a given point just like for a line.
-    // conic(ccx, ccy) === det / k00 where k00 is the discriminant
+    // For the conic center, with ccx = k10 / k00 and ccy = k01 / k00,
+    // conic(ccx, ccy) === det / k00 where k00 is the discriminant.
     // When (conic(x, y) < 0) === (det < 0) the point is inside the conic.
     // Note that this distinction is arbitrary for degenerate conics.
     function conic(x, y) {
@@ -550,12 +547,10 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
     var xBottom = solveRealQuadratic( // y = csh
         c20, c11 * csh + c10, (c02 * csh + c01) * csh + c00);
 
-    // For ovals compute the roots of the x and y discriminant for
+    // Compute the roots of the x and y discriminant for
     // the horizontal and vertical tangent points respectively
-    var flats = k00 <= 0 ? [null, null] : [
-        solveRealQuadratic(k00, -2 * k10, k20),
-        solveRealQuadratic(k00, -2 * k01, k02)
-    ];
+    var xFlat = solveRealQuadratic(k00, -2 * k10, k20);
+    var yFlat = solveRealQuadratic(k00, -2 * k01, k02);
 
     var points = [];
 
@@ -605,19 +600,17 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
             if ((sol[0] - eps < coord && coord < sol[1] + eps) === smInside)
                 cleanPush(vert, other, coord, "corner");
         } else {
-            var x, y;
-            var flat = flats[vert ? 0 : 1];
-            if (flat) {
-                flat = flat[other === 0 ? 0 : 1];
+            if (k00 >= 0) {
+                var x, y;
                 if (vert) { // xFlat for vertical tangent to oval
-                    x = flat;
+                    x = xFlat[fwd ? 0 : 1];
                     if (0 - eps < x && x < csw + eps) {
                         y = -0.5 * (c11 * x + c01) / c02;
                         if (0 - eps < y && y < csh + eps)
                             points.push(mkp(x, y, "split"));
                     }
                 } else { // !vert => yFlat for horizontal tangent to oval
-                    y = flat;
+                    y = yFlat[fwd ? 1 : 0];
                     if (0 - eps < y && y < csh + eps) {
                         x = -0.5 * (c11 * y + c10) / c20;
                         if (0 - eps < x && x < csw + eps)
@@ -643,9 +636,10 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
     if (n < 2) return; // Nothing to draw
     var j = 0;
     var previousBegin = null;
-    // For hyperbola with its center within the boundaries, setup to
+    // For a hyperbola with any flats within the boundaries, setup to
     // draw arc from "end" to back to previous "begin"
-    if (k00 < 0 && 0 < ccx && ccx < csw && 0 < ccy && ccy < csh) {
+    if (k00 < 0 && !(xFlat && (xFlat[1] < 0 || csw < xFlat[0])) &&
+        !(yFlat && (yFlat[1] < 0 || csh < yFlat[0]))) {
         for (j = 0; j < n; ++j) {
             if (points[j].t === "begin") {
                 previousBegin = points[j];

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -643,7 +643,7 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
         }
         previous = next;
     }
-	
+
     if (csctx.special) { // begin DEBUG code
         for (i = 0; i < points.length; ++i)
             csctx.special.push([points[i].x, points[i].y]);

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -710,7 +710,7 @@ eval_helper.drawconic = function(conicMatrix, modifs) {
         var dx = cx - mx;
         var dy = cy - my;
         var s = dx * dx + dy * dy;
-        if (s < maxError) {
+        if (s * k * k < maxError) {
             csctx.lineTo(x2, y2);
         } else if (s * j * j < maxError) {
             csctx.lineTo(cx, cy);

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -623,7 +623,7 @@ eval_helper.drawconic = function(conicMatrix, modifs, df) {
                 if (j >= 0) {
                     // When second "begin" is found, rotate the points
                     // if needed so that the first "begin" is at start
-                    if (j != 0) {
+                    if (j !== 0) {
                         points = points.slice(j).concat(points.slice(0, j));
                     }
                     previousBegin = points[0];

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -63,7 +63,7 @@ function drawgeoconic(el) {
     modifs.alpha = el.alpha;
     modifs.size = el.size;
 
-    eval_helper.drawconic(el.matrix, modifs);
+    eval_helper.drawconic(el.matrix, modifs, "D");
 
 
 }


### PR DESCRIPTION
The code for computing `k` was changed to work optimally. This way, other then NaN, `k` absolutely cannot assume values other than between zero and one inclusively. Only one square root is needed this way, also helping with numerical precision. Changing the sign of all the `c##` no longer affects the computation of `k`.