### PR TITLE
Provide filling support for conics

### DIFF
--- a/examples/63_Conic.html
+++ b/examples/63_Conic.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
-            <title>Cindy JS</title>
+            <title>63_Conic</title>
             <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
             </head>
@@ -34,7 +34,7 @@
                       {name:"C", type:"Free", pos:[0,-2]},
                       {name:"D", type:"Free", pos:[5,0]},
                       {name:"E", type:"Free", pos:[-6,0]},
-		              {name:"Co", type:"ConicBy5", args:["A","B","C","D","E"],color:[0,0,1],alpha:1,size:1},
+		              {name:"Co", type:"ConicBy5", args:["A","B","C","D","E"],color:[0,0,1],alpha:1,fillcolor:[0,0,1],fillalpha:5/13,size:1},
 //		     {name:"l", type:"Join", args:["A", "D"]}
                       ];
             var cdy=CindyJS({canvasname:"CSCanvas",
@@ -51,11 +51,12 @@
                 ["degen1", [0,4,1], [0,3,1], [0,-2,1], [5,0,1], [-6,0,1]],
                 ["degen2", [0,1,0.25], [0,1,0.3333333333333333], [0,1,-0.5], [1,0.23931623931623938,0.21367521367521372], [1,0,-0.16666666666666666]],
                 ["degen3", [0,1,0.25], [0.9999999999999999,-0.7826086956521738,-0.3623188405797101], [0,1,-0.5], [1,0,0.2], [1,0,-0.16666666666666666]],
-["degen4", [-0.25, 1, 0.125], [0.4953271028037384, 1, 0.23364485981308416], [1, 0.33333333333333326, 0.16666666666666663], [1, 1, 0.5], [0.5, 1, 0.5]],
+                ["degen4", [-0.25, 1, 0.125], [0.4953271028037384, 1, 0.23364485981308416], [1, 0.33333333333333326, 0.16666666666666663], [1, 1, 0.5], [0.5, 1, 0.5]],
                 ["degen5", [-0.25, 1, 0.125], [0.5643564356435643, 1, 0.24752475247524752], [1, 0.3333333333333333, 0.16666666666666666], [1, 1, 0.5], [0.5, 1, 0.5]],
                 ["degen6", [-0.4962406015037595, 1, 0.09398496240601504], [0.4, 1, 0.2], [1, 0.3333333333333333, 0.16666666666666666], [1, 0.6666666666666666, 0.3333333333333333], [1, 1, 0.5]],
                 ["degen7", [-0.09883720930232559, 1, 0.1453488372093023], [0.4, 1, 0.2], [1, 0.3333333333333333, 0.16666666666666666], [1, 0.6666666666666666, 0.3333333333333333], [1, 1, 0.5]],
                 ["degen8", [-0.5111111111111112, 1, 0.0925925925925926], [0.4, 1, 0.2], [1, 0.3333333333333333, 0.16666666666666666], [1, 0.6666666666666666, 0.3333333333333333], [1, 1, 0.5]],
+                ["sameLines", [1,-2,1], [-7,-6,1], [-3,-4,1], [9,2,1], [5,0,1]],
                 ["almost degen", [0,1,0.25], [0.9999999999999999,0.16666666666666666,0.09689922480620154], [0,1,-0.5], [1,0.23931623931623938,0.21367521367521372], [1,0,-0.16666666666666666]],
                 ["almost2", [0,1,0.25], [1,0.16666666666666674,0.09689922480620156], [0.6105263157894737,1,-0.26315789473684215], [1,0.24545454545454548,0.2272727272727273], [1,0,-0.16666666666666666]],
                 ["almost3", [0,1,0.25], [1,0.7410071942446044,0.1798561151079137], [-0.8492063492063492,1,-0.1984126984126984], [1,0,0.2], [1,0,-0.16666666666666666]],
@@ -93,7 +94,16 @@
                 };
             });
         </script>
-
-
+<fieldset style="width:25%"><legend>Appearance</legend>
+curve size:0<input id="curveSize" type="range" onchange="cdy.evokeCS('Co.size='+document.getElementById('curveSize').value)" defaultvalue="1" value="1" min="0" max="10" />10
+<br>
+curve alpha:0<input id="curveAlpha" type="range" onchange="cdy.evokeCS('Co.alpha='+(document.getElementById('curveAlpha').value/13))" defaultvalue="13" value="13" min="0" max="13" />1
+<br>
+curve color:<input id="curveColorPicker" onchange="cdy.evokeCS('Co.color=['+([1,3,5].map(function(o){return parseInt(this.substr(o, 2), 16) / 255;}, document.getElementById('curveColorPicker').value))+']')" defaultvalue="#0000ff" value="#0000ff" style="width:12%;" type="color">
+<br>
+fill alpha:0<input id="fillAlpha" type="range" onchange="cdy.evokeCS('Co.fillalpha='+(document.getElementById('fillAlpha').value/13))" defaultvalue="5" value="5" min="0" max="13" />1
+<br>
+fill color:<input id="fillColorPicker" onchange="cdy.evokeCS('Co.fillcolor=['+([1,3,5].map(function(o){return parseInt(this.substr(o, 2), 16) / 255;}, document.getElementById('fillColorPicker').value))+']')" defaultvalue="#0000ff" value="#0000ff" style="width:12%;" type="color">
+</fieldset>
 	</body>
 </html>

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -136,7 +136,17 @@ function textDefault(el) {
 }
 
 function polygonDefault(el) {
-    el.filled = (el.filled !== undefined ? General.bool(el.filled) : General.bool(true));
+    el.filled = el.filled !== undefined ? el.filled : true;
+    if (el.fillcolor === undefined) el.fillcolor = nada;
+    else el.fillcolor = List.realVector(el.fillcolor);
+    if (el.fillalpha === undefined) el.fillalpha = 0;
+    el.fillalpha = CSNumber.real(el.fillalpha);
+
+    lineDefault(el);
+}
+
+function conicDefault(el) {
+    el.filled = el.filled !== undefined ? el.filled : false;
     if (el.fillcolor === undefined) el.fillcolor = nada;
     else el.fillcolor = List.realVector(el.fillcolor);
     if (el.fillalpha === undefined) el.fillalpha = 0;
@@ -271,7 +281,7 @@ function addElementNoProof(el) {
     }
     if (el.kind === "C") {
         csgeo.conics.push(el);
-        lineDefault(el);
+        conicDefault(el);
     }
     if (el.kind === "S") {
         csgeo.lines.push(el);

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -58,14 +58,18 @@ function drawgeoconic(el) {
     if (!el.isshowing || el.visible === false)
         return;
 
-    var modifs = {};
-    modifs.color = el.color;
-    modifs.alpha = el.alpha;
-    modifs.size = el.size;
+    var modifs = {
+        color: el.color,
+        alpha: el.alpha,
+        fillcolor: el.fillcolor,
+        fillalpha: el.fillalpha,
+        size: el.size,
+    };
 
-    eval_helper.drawconic(el.matrix, modifs, "D");
+    // check if we have filled: true
+    var df = el.filled ? "F" : "D";
 
-
+    eval_helper.drawconic(el.matrix, modifs, df);
 }
 
 function drawgeoline(el) {


### PR DESCRIPTION
These changes support using `eval_helper.drawconic` to handle filling of conics. [63_Conic.html](https://github.com/gagern/CindyJS/blob/50bd48b4c745bd44a0dfa27b8539a2e7db9838d1/examples/63_Conic.html) now has an appearance manipulation section to demonstrate this.