### PR TITLE
fix wrong timing, use soundfont with percussion, remove timeoffset for pachelbel-canon

### DIFF
--- a/examples/sound/Canon.html
+++ b/examples/sound/Canon.html
@@ -144,7 +144,7 @@ drawit() := (
   translate((0, -3));
   forall(1..5, draw((-100, #), (100, #), color->[0,0,0]));
   forall(-1..1, draw((8*xscale*#, -2), (8*xscale*#, 8), color->[0,0,1]));
-  now = if(played, midiposition() - 2, 0);
+  now = if(played, midiposition(), 0);
   translate((xscale*(16 - now), 0));
   forall(score, note,
     if (note_2 > 1,

--- a/plugins/midi/src/js/midi-plugin.js
+++ b/plugins/midi/src/js/midi-plugin.js
@@ -3,7 +3,10 @@ CindyJS.registerPlugin(1, "midi", function(api) {
     "use strict";
 
     //var soundfont = CindyJS.getBaseDir() + "soundfont/";
-    var soundfont = "http://cindyjs.org/extras/midi-js-soundfonts/MusyngKite/";
+    //var soundfont = "http://cindyjs.org/extras/midi-js-soundfonts/MusyngKite/"; //does not have percussion-ogg.js 
+    var soundfont = "http://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/"; //we would like to have that on cindyjs.org
+    
+    console.log(soundfont);
 
     var midijsStatus = -2; // wait for two scripts to load
 
@@ -310,7 +313,7 @@ CindyJS.registerPlugin(1, "midi", function(api) {
     });
 
     function playMelody(t0, melody) {
-        var melodyStartTime = t0;
+        melodyStartTime = t0;
         var maxChunk = 20;
         if (melody.length > maxChunk) {
             var delta = (melody[maxChunk].time + t0 - MIDI.now()) * 1000 - 200;


### PR DESCRIPTION
This fixes the bug with the time offset.
However, we need some `percussion-ogg.js` into http://cindyjs.org/extras/midi-js-soundfonts/MusyngKite/ to make `EuklidRhythm4a.html` work